### PR TITLE
Drop Python 3.8 from CI and declared support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.11]
+        python-version: [3.11]
         pytest-specifier: ['-m "not slow"']
         include:
-          - python-version: 3.8
-            pytest-specifier: 'tests/test_examples.py::test_suzuki_example'
           - python-version: 3.11
             pytest-specifier: 'tests/test_examples.py::test_dppe_example'
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         include:
           - python-version: 3.11
             pytest-specifier: 'tests/test_examples.py::test_dppe_example'
+          - python-version: 3.11
+            pytest-specifier: 'tests/test_examples.py::test_suzuki_example'
           
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_tmate.yml
+++ b/.github/workflows/test_tmate.yml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v3
       with:
-        python-version: "3.8"
+        python-version: "3.11"
         cache: pip
         cache-dependency-path: pyproject.toml
     - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "py-conformational-sampling"
 version = "0.6.4"
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.9,<3.12"
 authors = [
     { name = "Joshua Kammeraad" },
     { name = "Soumik Das"},


### PR DESCRIPTION
- [x] Implement changes
- [ ] Update documentation
- [ ] Update tests
- [ ] Look through pull request changes
- [ ] Clean up code and retest
- [ ] Increment version number

Closes N/A

## Why
Every CI run on Python 3.8 has been failing (confirmed back through `alex/adaptation` pushes in December 2025, unrelated to PR #90's changes): `nglview`'s build backend requires `setuptools>=75.6.0`, and no setuptools version satisfying that also still supports Python 3.8 (they all require `>=3.9`). That's PyPI's available package set moving on, not anything in this repo. The 3.8 floor was for external collaborators (per PR #64/#66 history) who are no longer active, so drop it rather than chase a workaround for an unsupported version.

## What changed
- `ci.yml`: matrix now just `[3.11]`. `test_suzuki_example` (previously only run under the 3.8 leg — apparently to spread the two slow tests across both Python versions rather than double one job's runtime) now runs as its own separate 3.11 matrix entry alongside `test_dppe_example`, so they still run in parallel rather than serially in one job.
- `pyproject.toml`: `requires-python` floor raised `3.8` → `3.9`.
- `test_tmate.yml` (manual debugging workflow): bumped off 3.8 for the same reason — `pip install -e .` there would hit the identical resolution failure.